### PR TITLE
Kenwood TH-D74 Bluetooth TNC Support initial support

### DIFF
--- a/overlay/opt/emcomm-tools/bin/et-th-d74
+++ b/overlay/opt/emcomm-tools/bin/et-th-d74
@@ -1,0 +1,253 @@
+#!/bin/bash
+#
+# Author   : William McKeehan
+# Date     : 4 January 2025
+# Based On : et-uv-pro
+# Purpose  : Utility for accessing the Bluetooth TNC on the 
+#            Kenwood TH-D74.
+
+ACTIVE_RADIO="${ET_HOME}/conf/radios.d/kenwood-thd74.bt.json"
+DEVICE_NAME=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.deviceName)
+BLUETOOTH_CHANNEL=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.channel)
+BT_DEVICE="/dev/rfcomm0"
+AX25_PORT="pkt1200"
+AX25_CONF_FILE="/etc/ax25/axports"
+
+ESC="\x1B"
+RED="${ESC}[1;31m"
+BLUE="${ESC}[1;34m"
+GREEN="${ESC}[1;32m"
+WHITE="${ESC}[97m"
+YELLOW="${ESC}[1;33m"
+NC="${ESC}[0m"
+
+function usage() {
+  echo "Usage: $(basename $0) <command>"
+  echo "  connect - Connect to radio via Bluetooth" 
+  echo "  pair    - Pair radio (one-time operation)" 
+  echo "  unpair  - Unpair radio" 
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+error_message() {
+  echo -e "${RED}"
+  et-log $*
+  echo -e "${NC}"
+}
+
+info_message() {
+  echo -e "${BLUE}"
+  et-log $*
+  echo -e "${NC}"
+}
+
+success_message() {
+  echo -e "${GREEN}"
+  et-log $*
+  echo -e "${NC}"
+}
+
+exit_if_no_active_radio () {
+  if [ ! -e ${ACTIVE_RADIO} ]; then
+    error_message "${ACTIVE_RADIO} file not found"    
+    exit 1
+  fi
+}
+
+get_mac_or_exit () {
+  MAC=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.mac)
+  if [ $? -ne 0 ]; then
+    error_message "No MAC address found in ${ACTIVE_RADIO}."
+    exit 1
+  fi
+}
+
+update_ax25_conf() {
+
+  [ -z "$ET_USER_CONFIG" ] && ET_USER_CONFIG="${HOME}/.config/emcomm-tools/user.json"
+
+  CALLSIGN=$(cat ${ET_USER_CONFIG} | jq -r .callsign)
+
+  if [ "${CALLSIGN}" = "N0CALL" ]; then
+    error_message "No callsign set. Run et-user first."
+    exit 1
+  fi
+
+  GREP_OUT=$(grep ${AX25_PORT} ${AX25_CONF_FILE})
+  if [ $? -eq 0 ]; then
+    # Delete all existing pkt1200 entries. Note: we can't use sed here
+    # since we do not have permission to create a temporary file with
+    # inline replacement. ed modifies the file directly.
+    printf "g/^pkt1200/d\nw\nq\n" | ed ${AX25_CONF_FILE} > /dev/null 2>&1
+
+  fi
+
+  info_message "Adding AX25 port for ${CALLSIGN}"
+  echo "pkt1200 ${CALLSIGN} 1200 255	2 1200 Packet" >> ${AX25_CONF_FILE}
+}
+
+stop_all_services() {
+
+  PS_OUT=$(ps -ef | grep [k]issattach) 
+  if [ $? -eq 0 ]; then
+    info_message "Killing kissattach process(es)..."
+    sudo killall kissattach
+  fi
+ 
+  sleep 3
+
+  PS2_OUT=$(ps -ef | grep -v krfcommd | grep [r]fcomm) 
+  if [ $? -eq 0 ]; then
+    info_message "Killing rfcomm process(es)..."
+    sudo killall rfcomm
+  fi
+}
+
+exit_if_no_active_radio
+
+case $1 in
+  pair)
+
+    MAC=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.mac)
+    if [ $? -eq 0 ]; then
+      PAIR_STATUS=$(bluetoothctl info "${MAC}" | grep "Paired:" | awk '{print $2}')
+      if [ "${PAIR_STATUS}" == "yes" ]; then
+         error_message "Device with MAC ${MAC} is already paired."
+         exit 1
+      fi
+    fi 
+
+    echo -e "${YELLOW}"
+    echo -e "1. Turn on the Kenwood TH-D74"
+    echo -e "2. Goto Menu > Configuration > Bluetooth > Pairing Mode"
+    read -p "3. Press [ENTER] when done."
+
+    info_message "Searching for ${DEVICE_NAME}..."
+
+    HCI_OUT=$(hcitool scan | grep "${DEVICE_NAME}")
+    if [ $? -ne 0 ]; then
+      error_message "Can't find ${DEVICE_NAME}. Make sure that the radio is on and in pairing mode."
+      exit 1
+    fi
+
+	MAC=$(echo ${HCI_OUT} | awk '{print $1}')
+
+    # Update configuration file detected MAC address
+    sed -i "s|.*mac.*|    \"mac\": \"${MAC}\"|g" ${ACTIVE_RADIO}
+
+    # Generate an expect script to automatically pair our device.
+    PAIR_SCRIPT="${HOME}/pair"
+
+cat <<EOF > ${PAIR_SCRIPT}
+#!/usr/bin/expect -f
+
+set device "${MAC}"
+set timeout 60
+
+spawn bluetoothctl
+expect "Agent registered"
+send "power on\r"
+expect "Changing power on succeeded"
+send "scan on\r"
+expect "${MAC}"
+send "pair ${MAC}\r"
+expect "Enter PIN code"
+send "0000\r"
+expect "Pairing successful"
+send "trust ${MAC}\r"
+expect "trust succeeded"
+send "exit\r"
+expect eof
+EOF
+
+    sleep 1 && chmod 755 ${PAIR_SCRIPT} && expect ${PAIR_SCRIPT}
+
+    ;;
+  unpair)
+    MAC=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.mac)
+    if [ $? -ne 0 ]; then
+      error_message "No MAC found in radio configuration file."
+      exit 1
+    fi 
+
+    PAIR_STATUS=$(bluetoothctl info "${MAC}")
+    if [ $? -ne 0 ]; then
+       error_message "No device with ${MAC} found. Can't unpair."
+       exit 1
+    fi
+
+    info_message "Unpairing ${DEVICE_NAME}..."
+    bluetoothctl untrust ${MAC}
+    bluetoothctl remove ${MAC}
+
+    echo -e "${YELLOW}"
+    echo -e "You may also want to remove this device from your Kenwood TH-D74"
+    echo -e "under Menu > Configuration > Bluetooth > Connect > <select device> > Menu > Clear" 
+    echo -e "${NC}"
+
+    ;;
+  connect)
+    get_mac_or_exit
+
+    echo -e "${YELLOW}"
+    echo -e "1. Turn on the Kenwood TH-D74"
+    echo -e "2. Menu > Configuration > Bluetooth > On"
+    echo -e "3. Menu > Configuration > Interface > KISS > Bluetooth"
+    read -p "4. Press [ENTER] when done."
+
+    is_paired=$(bluetoothctl info ${MAC} | grep "Paired" | awk '{print $2}')
+    if [ "${is_paired}" != "yes" ]; then
+    echo -e "${RED}"
+      et-log "${DEVICE_NAME} is not paired. Run: '$(basename $0) pair'"
+      echo -e "${NC}"
+      exit 1
+    fi  
+ 
+    echo -e "${GREEN}Found ${DEVICE_NAME} with MAC address: ${MAC}" 
+    stop_all_services
+
+    update_ax25_conf 
+
+    echo -e "${BLUE}Connecting to radio..." 
+    sudo rfcomm connect ${BT_DEVICE}  ${MAC} ${BLUETOOTH_CHANNEL} 1>/dev/null 2>&1 &
+
+    sleep 10 && reset
+
+    if [ -e "${BT_DEVICE}"  ]; then
+      echo -e "${GREEN}${DEVICE_NAME} connected via Bluetooth serial${NC}" 
+    else
+      echo -e "${RED}${DEVICE_NAME} failed to connect via Bluetooth serial${NC}"
+      exit 1
+    fi
+
+    echo -e "${BLUE}Connecting KISS interface using ${BT_DEVICE} and AX.25 port: ${AX25_PORT}${NC}"
+    KISS_OUT=$(sudo kissattach ${BT_DEVICE} ${AX25_PORT})
+    
+    if [ $? -eq 0 ]; then
+      echo -e "${GREEN}Packet port ready"
+    else 
+      echo -e "${RED}Failed to setup radio for packet.${NC}"
+      exit 1
+    fi
+
+    KISS_OUT=$(sudo kissparms -c 1 -p ${AX25_PORT})
+
+    echo -e "${YELLOW}"
+    echo -e "SAMPLE COMMANDS                  DESCRIPTION                     "
+    echo -e "-------------------------------  --------------------------------"
+    echo -e "axcall pkt1200 <STATION>         Connect directly to a node      "
+    echo -e "axcall pkt1200 <STATION> <DIGI>  Connect to node via a digipeater"
+    echo -e "sudo axlisten -a -tttt -c        Monitor inbound and outbound traffic"
+    echo -e "${NC}"
+
+    ;;
+  *)
+    et-log "Invalid command."
+    usage
+    exit 1
+  ;;
+esac

--- a/overlay/opt/emcomm-tools/conf/radios.d/kenwood-thd74.bt.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/kenwood-thd74.bt.json
@@ -1,0 +1,16 @@
+{
+  "id": "kenwood-thd74",
+  "vendor": "Kenwood",
+  "model": "TH-D74 (BT)",
+  "bluetooth": {
+    "deviceName" : "TH-D74",
+    "channel": "2",
+    "mac": ""
+  },
+  "notes": [
+    "Menu > Configuration > Bluetooth > On",
+    "Menu > Configuration > Interface > KISS > Bluetooth"
+  ],
+  "fieldNotes": [
+  ]
+}


### PR DESCRIPTION
This PR adds support for bluetooth connectivity to the Kenwood TH-D74 TNC. The logic/code was cloned from the BTECH UV Pro and modified for the Kenwood.