### PR TITLE
Bug fix for Pup installer

### DIFF
--- a/scripts/install-pup.sh
+++ b/scripts/install-pup.sh
@@ -18,6 +18,8 @@ curl -s -f -L -o ${ZIP_FILE} ${URL}
 
 [[ $? -ne 0 ]] && et-log "Error fetching pup" && exit 1 
 
+[ ! -e $ET_DIST_DIR ] && mkdir -v $ET_DIST_DIR
+
 mv -v ${ZIP_FILE} ${ET_DIST_DIR}
 
 CWD_DIR=$(pwd)


### PR DESCRIPTION
The Pup installer fails to check for presence of dest dir, which creates a file containing the Pup zip file instead of a directory for the zip file. This error breaks downstream install scripts using this same dest dir approach.