### PR TITLE
Elecraft KX2 Support

### DIFF
--- a/overlay/opt/emcomm-tools/conf/radios.d/elecraft-kx2.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/elecraft-kx2.json
@@ -1,0 +1,16 @@
+{
+  "id": "elecraft-kx2",
+  "vendor": "Elecraft",
+  "model": "KX-2 (DigiRig)",
+  "rigctrl": {
+    "id": "2044",
+    "baud": "38400",
+    "ptt": "RTS"
+  },
+  "notes": [
+    "In Menu set RS232 to 38400 b",
+    "Note current Mic Gain setting then set to 5 (ALC meter should read 3-5 bars during TX)",
+    "Set AF Gain to 15 (ensure input level is green in JS8CALL)",
+    "For voice operation, return Mic Gain to setting noted above (25 typical)"
+  ]
+}


### PR DESCRIPTION
Initial support for the Elecraft KX2. This has been tested with the HF capabilbilities in Emcomm Tools R4B19. Namely, JS8CALL and PAT WINLINK ARDOP. If there are other capabilities that should be tested prior to the R4 release, please let me know!