### PR TITLE
bugfix: Pat Winlink does not populate proper GPS values for position report

### DIFF
--- a/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ardop.json
+++ b/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ardop.json
@@ -73,8 +73,8 @@
     "ptt_ctrl": false
   },
   "gpsd": {
-    "enable_http": false,
-    "allow_forms": false,
+    "enable_http": true,
+    "allow_forms": true,
     "use_server_time": false,
     "addr": "localhost:2947"
   },

--- a/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ax25-agw.json
+++ b/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ax25-agw.json
@@ -73,8 +73,8 @@
     "ptt_ctrl": false
   },
   "gpsd": {
-    "enable_http": false,
-    "allow_forms": false,
+    "enable_http": true,
+    "allow_forms": true,
     "use_server_time": false,
     "addr": "localhost:2947"
   },

--- a/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ax25-native.json
+++ b/overlay/opt/emcomm-tools/conf/template.d/winlink/config.ax25-native.json
@@ -68,8 +68,8 @@
     "ptt_ctrl": false
   },
   "gpsd": {
-    "enable_http": false,
-    "allow_forms": false,
+    "enable_http": true,
+    "allow_forms": true,
     "use_server_time": false,
     "addr": "localhost:2947"
   },

--- a/overlay/opt/emcomm-tools/conf/template.d/winlink/config.vara-fm.json
+++ b/overlay/opt/emcomm-tools/conf/template.d/winlink/config.vara-fm.json
@@ -73,8 +73,8 @@
     "ptt_ctrl": true
   },
   "gpsd": {
-    "enable_http": false,
-    "allow_forms": false,
+    "enable_http": true,
+    "allow_forms": true,
     "use_server_time": false,
     "addr": "localhost:2947"
   },

--- a/overlay/opt/emcomm-tools/conf/template.d/winlink/config.vara-hf.json
+++ b/overlay/opt/emcomm-tools/conf/template.d/winlink/config.vara-hf.json
@@ -73,8 +73,8 @@
     "ptt_ctrl": true
   },
   "gpsd": {
-    "enable_http": false,
-    "allow_forms": false,
+    "enable_http": true,
+    "allow_forms": true,
     "use_server_time": false,
     "addr": "localhost:2947"
   },


### PR DESCRIPTION
Update config templates to enable GPS data for the standard Pat web pages and forms.