### PR TITLE
Merge rigcontrol/bg2fx-fx4cr to release/r5

### DIFF
--- a/overlay/etc/udev/rules.d/89-et-bg2fx-fx4cr.rules
+++ b/overlay/etc/udev/rules.d/89-et-bg2fx-fx4cr.rules
@@ -1,0 +1,23 @@
+# Author   : Gaston Gonzalez
+# Date     : 18 September 2025
+# Purpose  : udev rules for the FX-4CR by BG2FX
+#
+# Preconditions:
+# 1. FX-4CR connected via USB cable
+#
+# Postconditions:
+# 1. /dev/et-cat created
+# 2. rigctld is started
+# 3. /dev/et-audio created
+
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", ENV{ET_DEVICE}=="", \
+    ACTION=="add", \
+    ENV{ET_DEVICE}="FX-4CR", ENV{ET_SUBDEVICE}="CAT", GROUP="dialout", MODE="0660", SYMLINK+="et-cat", \
+    RUN+="/usr/bin/systemctl start rigctld"
+
+#    PROGRAM="/opt/emcomm-tools/sbin/udev-tester.sh digirig-mobile", \
+SUBSYSTEM=="sound", ATTRS{idVendor}=="4c4a", ATTRS{idProduct}=="4155", \
+    ACTION=="add", \
+    ENV{ET_DEVICE}="FX-4CR", \
+    ATTR{id}="ET_AUDIO", \
+    ENV{ET_SUBDEVICE}="AUDIO", GROUP="audio", MODE="0660", SYMLINK+="et-audio"

--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -99,7 +99,7 @@ update-config () {
          ;;
          "FX-4CR")
            # Unmute the PCM and set the volume to 21% to get the full output power. This value is
-	   # dependent on the settings defined for the FX-4CR in the et-radio notes. 
+           # dependent on the settings defined for the FX-4CR in the et-radio notes. 
 	   amixer -q -c ${AUDIO_CARD} sset 'PCM' 31% unmute
 
            # Set "L/R Capture" to 55%. Adjust if you can't decode received audio.

--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -2,14 +2,14 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 31 October 2024
-# Updated : 13 September 2025
+# Updated : 26 September 2025
 # Purpose : Configures ET audio device with sane defaults
 #
 # Preconditions
 # 1. Supported audio interface is connected and properly detected
 #
 # Postconditions
-# 1. ASLA settings set on ET audio device
+# 1. ALSA settings set on ET audio device
 
 usage() {
   echo "usage: $(basename $0) <command>"
@@ -97,6 +97,19 @@ update-config () {
 
            et-log "Applied amixer settings for ${ET_DEVICE_NAME}"
          ;;
+         "FX-4CR")
+           # Unmute the PCM and set the volume to 21% to get the full output power. This value is
+	   # dependent on the settings defined for the FX-4CR in the et-radio notes. 
+	   amixer -q -c ${AUDIO_CARD} sset 'PCM' 31% unmute
+
+           # Set "L/R Capture" to 55%. Adjust if you can't decode received audio.
+	   amixer -q -c ${AUDIO_CARD} sset 'Mic' 67% unmute
+
+           # Disable Auto Gain Control
+           amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
+
+           et-log "Applied amixer settings for ${ET_DEVICE_NAME}"
+	   ;;
          *)
            et-log "No ALSA configuration specified for this ET_DEVICE."
          ;;

--- a/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
@@ -5,20 +5,24 @@
   "rigctrl": {
     "id": "2031",
     "baud": "115200",
-    "ptt": "RTS",
+    "ptt": "RIG",
+    "conf": "data_bits=8,serial_handshake=None,stop_bits=1,rts_state=OFF",
     "pttOnly": "false"
   },
   "notes": [
-    "THESE NOTES ARE A WORK IN PROGRESS",
     "Short press [PWR], then rotate AF knob until POW = 5.0",
     "Toggle [SSB] button until both USB and DIG appear",
     "Short press [M. V] until VFOA is displayed",
+    "Long press [MENU], rotate AF to BLUETOOTH, rotate TUNE and set to 0",
     "Set radio volume to 50",
-    "Set mic gain to ?",
-    "Set alsamixer PCM to ?",
-    "Set alsamixer Mic to 50",
+    "Set mic gain to 50",
+    "Set alsamixer PCM to 21",
+    "Set alsamixer Mic to 55",
     "Set alsamixer AFC to mm"
   ],
   "fieldNotes": [
+    "Tested with FX-4CR firmware version: 1.7.3 (2025/09/01)",
+    "You must force the RTS control line to low for audio output to work with the PTT",
+    "This is handled with rts_state=OFF using the --set-conf argument of rigctld"
   ]
 }

--- a/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
@@ -1,0 +1,24 @@
+{
+  "id": "bg2fx-fx4cr",
+  "vendor": "BG2FX",
+  "model": "FX-4CR",
+  "rigctrl": {
+    "id": "2031",
+    "baud": "115200",
+    "ptt": "RTS",
+    "pttOnly": "false"
+  },
+  "notes": [
+    "THESE NOTES ARE A WORK IN PROGRESS",
+    "Short press [PWR], then rotate AF knob until POW = 5.0",
+    "Toggle [SSB] button until both USB and DIG appear",
+    "Short press [M. V] until VFOA is displayed",
+    "Set radio volume to 50",
+    "Set mic gain to ?",
+    "Set alsamixer PCM to ?",
+    "Set alsamixer Mic to 50",
+    "Set alsamixer AFC to mm"
+  ],
+  "fieldNotes": [
+  ]
+}

--- a/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
@@ -18,7 +18,7 @@
     "Set mic gain to 50",
     "Set alsamixer PCM to 21",
     "Set alsamixer Mic to 55",
-    "Set alsamixer AFC to mm"
+    "Set alsamixer AGC to mm"
   ],
   "fieldNotes": [
     "Tested with FX-4CR firmware version: 1.7.3 (2025/09/01)",

--- a/overlay/opt/emcomm-tools/sbin/wrapper-rigctld.sh
+++ b/overlay/opt/emcomm-tools/sbin/wrapper-rigctld.sh
@@ -2,12 +2,15 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 9 October 2024
-# Updated : 31 May 2025
+# Updated : 26 September 2025
 # Purpose : Wrapper startup/shutdown script around systemd/rigctld
 
 ET_HOME=/opt/emcomm-tools
 ACTIVE_RADIO="${ET_HOME}/conf/radios.d/active-radio.json"
 CAT_DEVICE=/dev/et-cat
+
+# Additional configuration to pass to rigctld
+SET_CONF=""
 
 do_full_auto() {
   et-log "Found ET_DEVICE='${ET_DEVICE}'"
@@ -95,8 +98,14 @@ start() {
     exit 0
   fi
 
+  # Handle optional configuration settings
+  CONF=$(jq -e -r '.rigctrl.conf' "${ET_HOME}/conf/radios.d/active-radio.json")
+  if [[ $? -eq 0 ]]; then
+    SET_CONF="--set-conf=${CONF}"
+  fi
+
   # Generate command
-  CMD="rigctld -m ${ID} -r ${CAT_DEVICE} -s ${BAUD} -P ${PTT} "
+  CMD="rigctld -m ${ID} -r ${CAT_DEVICE} -s ${BAUD} -P ${PTT} ${SET_CONF}"
   et-log "Starting rigctld with: ${CMD}"
   $CMD
 }


### PR DESCRIPTION
Introduced an optional radio configuration parameter called "conf" to allow advanced options to be set on the rigctld daemon. This was needed as the FX-4CR requires that the PTT be triggered using CAT and the RTS control line is set to low.