### PR TITLE
misc/pre-r5-build12 -updates

### DIFF
--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -117,19 +117,6 @@ update-config () {
 
            et-log "Applied amixer settings for ${ET_DEVICE_NAME}"
          ;;
-         "FX-4CR")
-           # Unmute the PCM and set the volume to 21% to get the full output power. This value is
-           # dependent on the settings defined for the FX-4CR in the et-radio notes. 
-	   amixer -q -c ${AUDIO_CARD} sset 'PCM' 31% unmute
-
-           # Set "L/R Capture" to 55%. Adjust if you can't decode received audio.
-	   amixer -q -c ${AUDIO_CARD} sset 'Mic' 67% unmute
-
-           # Disable Auto Gain Control
-           amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
-
-           et-log "Applied amixer settings for ${ET_DEVICE_NAME}"
-         ;;
          *)
            et-log "No ALSA configuration specified for this ET_DEVICE."
          ;;

--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -2,7 +2,7 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 31 October 2024
-# Updated : 5 October 2025
+# Updated : 9 October 2025
 # Purpose : Configures ET audio device with sane defaults
 #
 # Preconditions
@@ -10,6 +10,7 @@
 #
 # Postconditions
 # 1. ALSA settings set on ET audio device
+. /opt/emcomm-tools/bin/et-common
 
 usage() {
   echo "usage: $(basename $0) <command>"
@@ -48,10 +49,27 @@ update-config () {
 
        et-log "Updating audio device: '${ET_DEVICE_NAME}' (${FULL_AUDIO_DEVICE})' for ALSA PnP configuration."
 
+       # Handle audio settings specifically if defined in the radio configuration
+       AUDIO_INIT_SCRIPT=$(jq -r -e '.audio.script' ${ET_ACTIVE_RADIO_CONF})
+       if [[ $? -eq 0 ]]; then
+         et-log "Executing audio configuration script: ${AUDIO_INIT_SCRIPT}"
+
+	 CMD="${AUDIO_INIT_SCRIPT} ${AUDIO_CARD} ${AUDIO_DEVICE}"
+	 et-log "Running command: ${CMD}"
+	 ${CMD}
+
+	 if [[ $? -ne 0 ]]; then
+	   et-log "Audio init script ${AUDIO_INIT_SCRIPT} failed. Can't start application."
+	   notify-user "Audio init script failed. Can't start application."
+	   exit 1
+	 fi
+	 
+	 exit 0
+       fi
+
+       # Handle audio generically for most sound card interfaces
        case ${ET_DEVICE_NAME} in
          "DIGIRIG_MOBILE")
-	   # TODO: 92% is needed for the TX-500MP. Revisit approach for setting speaker
-	   #       out differently across radios definitions.
            # Unmute Speaker a set volume. Adjust if remote station can't decode you. Your TX controls.
            amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 42% unmute
            # Unmute Mic

--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -54,17 +54,17 @@ update-config () {
        if [[ $? -eq 0 ]]; then
          et-log "Executing audio configuration script: ${AUDIO_INIT_SCRIPT}"
 
-	 CMD="${AUDIO_INIT_SCRIPT} ${AUDIO_CARD} ${AUDIO_DEVICE}"
-	 et-log "Running command: ${CMD}"
-	 ${CMD}
+         CMD="${AUDIO_INIT_SCRIPT} ${AUDIO_CARD} ${AUDIO_DEVICE}"
+         et-log "Running command: ${CMD}"
+         ${CMD}
 
-	 if [[ $? -ne 0 ]]; then
-	   et-log "Audio init script ${AUDIO_INIT_SCRIPT} failed. Can't start application."
-	   notify-user "Audio init script failed. Can't start application."
-	   exit 1
-	 fi
+         if [[ $? -ne 0 ]]; then
+           et-log "Audio init script ${AUDIO_INIT_SCRIPT} failed. Can't start application."
+           notify-user "Audio init script failed. Can't start application."
+           exit 1
+         fi
 	 
-	 exit 0
+         exit 0
        fi
 
        # Handle audio generically for most sound card interfaces

--- a/overlay/opt/emcomm-tools/bin/et-audio
+++ b/overlay/opt/emcomm-tools/bin/et-audio
@@ -2,7 +2,7 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 31 October 2024
-# Updated : 9 October 2025
+# Updated : 13 October 2025
 # Purpose : Configures ET audio device with sane defaults
 #
 # Preconditions
@@ -125,18 +125,6 @@ update-config () {
            # Set "L/R Capture" to 55%. Adjust if you can't decode received audio.
 	   amixer -q -c ${AUDIO_CARD} sset 'Mic' 67% unmute
 
-           # Disable Auto Gain Control
-           amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
-
-           et-log "Applied amixer settings for ${ET_DEVICE_NAME}"
-	   ;;
-         "X6100")
-           # Unmute Speaker a set volume. Adjust if remote station can't decode you.
-           amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 42% unmute
-           # Unmute Mic
-           amixer -q -c ${AUDIO_CARD} sset Mic Playback Switch 52% unmute
-           # Set "L/R Capture" to 19. Adjust if you can't decode received audio. 
-           amixer -q -c ${AUDIO_CARD} sset Mic Capture Switch 31% unmute
            # Disable Auto Gain Control
            amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
 

--- a/overlay/opt/emcomm-tools/bin/et-radio
+++ b/overlay/opt/emcomm-tools/bin/et-radio
@@ -2,7 +2,7 @@
 #
 # Author   : Gaston Gonzalez
 # Date     : 11 October 2024
-# Updated  : 16 March 2025
+# Updated  : 13 March 2025
 # Purpose  : A script for managaing plug-and-play radios
 source /opt/emcomm-tools/bin/et-common
 
@@ -18,7 +18,7 @@ while IFS= read -r radio; do
     MODEL=$(cat $radio | jq -r .model)
 
     options+=("$ID" "$VENDOR $MODEL")
-done < <(find $ET_HOME/conf/radios.d -type f | grep -v "bt.json" | sort)
+done < <(find $ET_HOME/conf/radios.d -type f -name \*.json | grep -v "bt.json" | sort)
 
 SELECTED_RADIO=$(dialog --clear --menu "Select a radio:" 21 60 10 "${options[@]}" 3>&1 1>&2 2>&3)
 exit_status=$?

--- a/overlay/opt/emcomm-tools/bin/et-yaac
+++ b/overlay/opt/emcomm-tools/bin/et-yaac
@@ -2,7 +2,7 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 3 November 2024
-# Updated : 16 March 2025
+# Updated : 13 October 2025
 # Purpose : Wrapper script for starting YAAC with PnP support
 #
 # Preconditions:
@@ -40,7 +40,7 @@ start() {
   update-config
   
   if [[ $? -eq 0 ]]; then
-    CMD="java -jar /opt/yaac/YAAC.jar"
+    CMD="java -Xms2g -Xmx6g -XX:+UseG1GC -jar /opt/yaac/YAAC.jar"
 
     PS_OUT=$(ps -ef | grep "[r]fcomm0")
     if [[ $? -eq 0 ]]; then

--- a/overlay/opt/emcomm-tools/conf/radios.d/audio/bg2fx-fx4cr.sh
+++ b/overlay/opt/emcomm-tools/conf/radios.d/audio/bg2fx-fx4cr.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Author  : Gaston Gonzalez
+# Date    : 13 October 2025
+# Purpose : Audio settings specific to the FX-4CR
+#
+# Preconditions
+# 1. Supported audio interface is connected and properly detected
+#
+# Postconditions
+# 1. ALSA settings set on ET audio device
+
+usage() {
+  echo "usage: $(basename $0) <ET audio card> <ET device name>"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+AUDIO_CARD=$1
+ET_DEVICE_NAME=$2
+
+# Unmute the PCM and set the volume to 21% to get the full output power. This value is
+# dependent on the settings defined for the FX-4CR in the et-radio notes. 
+amixer -q -c ${AUDIO_CARD} sset 'PCM' 31% unmute
+
+# Set "L/R Capture" to 55%. Adjust if you can't decode received audio.
+amixer -q -c ${AUDIO_CARD} sset 'Mic' 67% unmute
+
+# Disable Auto Gain Control
+amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
+
+et-log "Applied amixer settings for audio card ${AUDIO_CARD} on device ${ET_DEVICE_NAME}"

--- a/overlay/opt/emcomm-tools/conf/radios.d/audio/lab599-tx500mp.sh
+++ b/overlay/opt/emcomm-tools/conf/radios.d/audio/lab599-tx500mp.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Author  : Gaston Gonzalez
+# Date    : 9 October 2025
+# Purpose : Audio settings specific to the Lab599 TX-500MP
+#
+# Preconditions
+# 1. Supported audio interface is connected and properly detected
+#
+# Postconditions
+# 1. ALSA settings set on ET audio device
+
+usage() {
+  echo "usage: $(basename $0) <ET audio card> <ET device name>"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+AUDIO_CARD=$1
+ET_DEVICE_NAME=$2
+
+# Unmute Speaker and set the volume to 81. Adjust if the remote station
+# can't decode you or if there is not output power on TX.
+amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 92% unmute
+
+# Unmute Mic
+amixer -q -c ${AUDIO_CARD} sset Mic Playback Switch 52% unmute
+
+# Set "L/R Capture" to 19. Adjust if you can't decode received audio.
+amixer -q -c ${AUDIO_CARD} sset Mic Capture Switch 31% unmute
+
+# Disable Auto Gain Control
+amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
+
+et-log "Applied amixer settings for audio card ${AUDIO_CARD} on device ${ET_DEVICE_NAME}"

--- a/overlay/opt/emcomm-tools/conf/radios.d/audio/xiegu-x6100.sh
+++ b/overlay/opt/emcomm-tools/conf/radios.d/audio/xiegu-x6100.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Author  : Gaston Gonzalez
-# Date    : 9 October 2025
-# Purpose : Audio settings specific to the Lab599 TX-500MP
+# Date    : 13 October 2025
+# Purpose : Audio settings specific to the Xiegu X6100
 #
 # Preconditions
 # 1. Supported audio interface is connected and properly detected
@@ -22,9 +22,9 @@ fi
 AUDIO_CARD=$1
 ET_DEVICE_NAME=$2
 
-# Unmute Speaker and set the volume to 81. Adjust if the remote station
+# Unmute Speaker and set the volume to 27. Adjust if the remote station
 # can't decode you or if there is no output power on TX.
-amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 92% unmute
+amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 42% unmute
 
 # Unmute Mic
 amixer -q -c ${AUDIO_CARD} sset Mic Playback Switch 52% unmute

--- a/overlay/opt/emcomm-tools/conf/radios.d/audio/yaesu-ft857d.sh
+++ b/overlay/opt/emcomm-tools/conf/radios.d/audio/yaesu-ft857d.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Author  : Gaston Gonzalez
+# Date    : 14 October 2025
+# Purpose : Audio settings specific to the Yaesu FT-857D via DigiRig Mobile
+#
+# Preconditions
+# 1. Supported audio interface is connected and properly detected
+#
+# Postconditions
+# 1. ALSA settings set on ET audio device
+
+usage() {
+  echo "usage: $(basename $0) <ET audio card> <ET device name>"
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+AUDIO_CARD=$1
+ET_DEVICE_NAME=$2
+
+# Unmute Speaker a set volume. Adjust if remote station can't decode you. Your TX controls.
+amixer -q -c ${AUDIO_CARD} sset Speaker Playback Switch 42% unmute
+
+# Unmute Mic
+amixer -q -c ${AUDIO_CARD} sset Mic Playback Switch 52% unmute
+
+# Set "L/R Capture" to 19. Adjust if you can't decode received audio. Your RX controls.
+amixer -q -c ${AUDIO_CARD} sset Mic Capture Switch 25% unmute
+
+# Disable Auto Gain Control
+amixer -q -c ${AUDIO_CARD} sset 'Auto Gain Control' mute
+
+et-log "Applied amixer settings for audio card ${AUDIO_CARD} on device ${ET_DEVICE_NAME}"

--- a/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/bg2fx-fx4cr.json
@@ -9,6 +9,9 @@
     "conf": "data_bits=8,serial_handshake=None,stop_bits=1,rts_state=OFF",
     "pttOnly": "false"
   },
+  "audio": {
+    "script": "/opt/emcomm-tools/conf/radios.d/audio/bg2fx-fx4cr.sh"
+  },
   "notes": [
     "Short press [PWR], then rotate AF knob until POW = 5.0",
     "Toggle [SSB] button until both USB and DIG appear",

--- a/overlay/opt/emcomm-tools/conf/radios.d/lab599-tx500mp.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/lab599-tx500mp.json
@@ -8,6 +8,9 @@
     "ptt": "RTS",
     "pttOnly": "false"
   },
+  "audio": {
+    "script": "/opt/emcomm-tools/conf/radios.d/audio/lab599-tx500mp.sh"
+  },
   "notes": [
     "1. Set MENU 36 CAT PROTOCOL = TS2000",
     "2. Set MODE = DIGI",

--- a/overlay/opt/emcomm-tools/conf/radios.d/xiegu-x6100.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/xiegu-x6100.json
@@ -9,7 +9,7 @@
     "conf": "timeout=1000,retry=1,timeout_retry=1",
     "primeRig": true
   },
-    "audio": {
+  "audio": {
     "script": "/opt/emcomm-tools/conf/radios.d/audio/xiegu-x6100.sh"
   },
   "notes": [

--- a/overlay/opt/emcomm-tools/conf/radios.d/xiegu-x6100.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/xiegu-x6100.json
@@ -9,6 +9,9 @@
     "conf": "timeout=1000,retry=1,timeout_retry=1",
     "primeRig": true
   },
+    "audio": {
+    "script": "/opt/emcomm-tools/conf/radios.d/audio/xiegu-x6100.sh"
+  },
   "notes": [
     "Turn on radio",
     "Plug USB-C cable into the DEV port",

--- a/overlay/opt/emcomm-tools/conf/radios.d/yaesu-ft857d.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/yaesu-ft857d.json
@@ -7,6 +7,9 @@
     "baud": "38400",
     "ptt": "RTS"
   },
+  "audio": {
+    "script": "/opt/emcomm-tools/conf/radios.d/audio/yaesu-ft857d.sh"
+  },
   "notes": [
     "Menu 019 CAT RATE = 38400",
     "Menu 020 CAT = CAT",

--- a/scripts/install-emcomm-tools.sh
+++ b/scripts/install-emcomm-tools.sh
@@ -2,7 +2,7 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 6 October 2024
-# Updated : 1 November 2024
+# Updated : 9 October 2025
 # Purpose : Install EmComm Tools applications
 
 et-log "Installing EmComm Tools applications..."
@@ -17,6 +17,10 @@ et-log "Setting up permission for shared data access..."
 chgrp -v -R $ET_GROUP $ET_HOME/conf/radios.d
 chmod -v 775 $ET_HOME/conf/radios.d
 chmod -v 664 $ET_HOME/conf/radios.d/*.json
+
+chgrp -v -R $ET_GROUP $ET_HOME/conf/radios.d/audio
+chmod -v 775 $ET_HOME/conf/radios.d/audio
+chmod -v 664 $ET_HOME/conf/radios.d/audio/*.sh
 
 chgrp -v -R $ET_GROUP $ET_HOME/conf/template.d/packet
 chmod -v 775 $ET_HOME/conf/template.d/packet

--- a/scripts/install-hamlib.sh
+++ b/scripts/install-hamlib.sh
@@ -2,7 +2,7 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 25 November 2022
-# Updated : 6 October 2025
+# Updated : 13 October 2025
 # Purpose : Install hamlib for rig control (rigctld)
 set -e
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
@@ -12,7 +12,11 @@ trap 'et-log "\"${last_command}\" command failed with exit code $?."' ERR
 . ../overlay/opt/emcomm-tools/bin/et-common
 
 APP="hamlib"
-VERSION=4.6.5
+# The latest verion of Hamlib 4.6.5 has a problem with initial client
+# connections that can lead to rig control timeouts in applications like 
+# JS8Call. Rolling back to version 4.5 which was stable.
+#VERSION=4.6.5
+VERSION=4.5
 APP_AND_VERSION="${APP}-${VERSION}"
 INSTALL_DIR="/opt/${APP_AND_VERSION}"
 LINK_PATH="/opt/${APP}"


### PR DESCRIPTION
1. Introduced new audio.script property in the radio configuration to allow for per radio audio settings
2. Added audio setting overrides from the FX-4CR, Xiegu X6100, TX-500MP, and FT-857D
3. Rolled back hamlib to version 4.5. Version 4.6.5 introduces high latency for the first rig control client request
4. Defined larger Java heap when starting YAAC to allow for large OSM tile imports