### PR TITLE
Update et-th-d74

### DIFF
--- a/overlay/opt/emcomm-tools/bin/et-th-d74
+++ b/overlay/opt/emcomm-tools/bin/et-th-d74
@@ -148,7 +148,7 @@ case $1 in
   p|pair)
 
     MAC=$(cat ${ACTIVE_RADIO} | jq -e -r .bluetooth.mac)
-    if [ $? -eq 0 ]; then
+    if [[ "{$MAC}" != "" ]]; then
       PAIR_STATUS=$(bluetoothctl info "${MAC}" | grep "Paired:" | awk '{print $2}')
       if [ "${PAIR_STATUS}" == "yes" ]; then
          echo "Device with MAC ${MAC} is already paired."


### PR DESCRIPTION
When the jq (json query) command executes, it returns 0 if there is a .bluetooth.mac node in the json (which there is, and should be).  This means we can't use $? to see if there is a value in the node or not.  We need to check the value directly.

Verified that this fixes my pairing issues with the BTech UV-Pro in another commit.  I don't have a th-d74 but the code looks like it isn't radio-specific.