### PR TITLE
Merge misc/post-r5-build14-updates to release/r5

### DIFF
--- a/scripts/install-bbs-server.sh
+++ b/scripts/install-bbs-server.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 # Author  : Gaston Gonzalez
 # Date    : 8 November 2024
-# Updated : 26 March 2025
+# Updated : 12 November 2025
 # Purpose : Install Linbpq
 #
 # Notes:
 # These build steps are partially based on an article by the Modern Ham (KN4MKB).
 # https://themodernham.com/install-linbpq-bbs-packet-node-on-debian-ubuntu-and-raspbian/
+set -e
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+trap 'et-log "\"${last_command}\" command failed with exit code $?."' ERR
+
+. ./env.sh
+. ../overlay/opt/emcomm-tools/bin/et-common
+
 
 VERSION=latest
 FILE=linbpq
@@ -26,7 +33,8 @@ BBS_HOME="/etc/skel/.local/share/emcomm-tools/bbs-server"
 BBS_HOME_FILES="${BBS_HOME}/Files"
 
 et-log "Downloading web interface for LinBPQ from ${HTML_ZIP_URL}"
-curl -s -f -L -o ${HTML_ZIP_FILE} ${HTML_ZIP_URL}
+download_with_retries ${HTML_ZIP_URL} ${HTML_ZIP_FILE}
+
 
 if [[ $? -eq 0 ]]; then
 
@@ -61,7 +69,7 @@ URL="https://www.cantab.net/users/john.wiseman/Downloads/${FILE}"
 
 if [ ! -e ${FILE} ]; then
   et-log "Downloading Linbpq: ${URL}"
-  curl -s -L -o ${FILE} --fail ${URL}
+  download_with_retries ${URL} ${FILE}
 fi
 
 [ ! -e ${INSTALL_BIN_DIR} ] && mkdir -v -p ${INSTALL_BIN_DIR}

--- a/scripts/install-chattervox.sh
+++ b/scripts/install-chattervox.sh
@@ -2,12 +2,14 @@
 #
 # Author  : Gaston Gonzalez
 # Date    : 4 December 2024
+# Updated : 12 November 2025
 # Purpose : Install chattervox protocol
 set -e
 trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 trap 'et-log "\"${last_command}\" command failed with exit code $?."' ERR
 
 . ./env.sh
+. ../overlay/opt/emcomm-tools/bin/et-common
 
 NAME=chattervox
 VERSION=0.7.0
@@ -20,7 +22,7 @@ et-log "Installing ${NAME} ${VERSION}..."
 URL=https://github.com/brannondorsey/chattervox/releases/download/v${VERSION}/chattervox-linux-x64.tar.gz
 
 et-log "Downloading: ${URL}"
-curl -s -L -o ${TARBALL} --fail ${URL}
+download_with_retries ${URL} ${TARBALL}
 
 CWD_DIR=`pwd`
 

--- a/scripts/install-et-api.sh
+++ b/scripts/install-et-api.sh
@@ -11,7 +11,7 @@ trap 'et-log "\"${last_command}\" command failed with exit code $?."' ERR
 . ../overlay/opt/emcomm-tools/bin/et-common
 
 APP=et-api
-VERSION=1.1.0
+VERSION=1.1.1
 ET_API_JAR="emcomm-tools-api-${VERSION}.jar"
 BASE_URL="https://github.com/thetechprepper/et-api-java/releases/download/${VERSION}"
 

--- a/scripts/install-yaac.sh
+++ b/scripts/install-yaac.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 # Author  : Gaston Gonzalez
 # Date    : 3 November 2024
-# Updated : 7 November 2024
+# Updated : 12 November 2024
 # Purpose : Install YAAC
+set -e
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+trap 'et-log "\"${last_command}\" command failed with exit code $?."' ERR
+
+. ./env.sh
+. ../overlay/opt/emcomm-tools/bin/et-common
 
 VERSION=latest
 ZIP_FILE=YAAC.zip
@@ -14,7 +20,7 @@ et-log "Installing YAAC..."
 URL=https://www.ka2ddo.org/ka2ddo/${ZIP_FILE}
 
 et-log "Downloading YAAC: ${URL}"
-curl -s -L -o ${ZIP_FILE} --fail ${URL}
+download_with_retries ${URL} ${ZIP_FILE}
 
 mv -v ${ZIP_FILE} ${ET_DIST_DIR}
 

--- a/tests/test-et-predict.sh
+++ b/tests/test-et-predict.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Author   : Gaston Gonzalez
+# Date     : 12 November 2025
+# Purpose  : Test et-predict installation
+
+OUT=$(which et-predict-app)
+exit $?


### PR DESCRIPTION
- Fixed an issue with the et-api and et-predict's callsign search when on-board GPS is not present. Using et-api 1.1.1.
- Replaced curl commands with the new retry downloader for any install sub modules that failed a fetch during the main installation process.
-  Added missing test case for et-predict