### PR TITLE
Do not brake PATH semantics

### DIFF
--- a/overlay/etc/environment
+++ b/overlay/etc/environment
@@ -4,4 +4,3 @@ ET_TEMP_DIR=/tmp/et
 ET_LOG_FILE=$ET_TEMP_DIR/et.log
 ET_DIST_DIR=/opt/dist
 ET_SRC_DIR=/opt/src
-PATH="/opt/emcomm-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"

--- a/overlay/etc/profile.d/emcomm-tools.sh
+++ b/overlay/etc/profile.d/emcomm-tools.sh
@@ -1,0 +1,1 @@
+export PATH=/opt/emcomm-tools/bin:$PATH

--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -8,6 +8,7 @@ set -e
 
 et-log "Installing environment variables..."
 cp -v ../overlay/etc/environment /etc/
+cp -v ../overlay/etc/profile.d/emcomm-tools.sh /etc/profile.d/
 
 et-log "Installing message of the day..."
 cp -v ../overlay/etc/motd /etc/

--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -6,13 +6,6 @@
 # Purpose : Install base tools and configuration
 set -e
 
-et-log "Installing environment variables..."
-cp -v ../overlay/etc/environment /etc/
-cp -v ../overlay/etc/profile.d/emcomm-tools.sh /etc/profile.d/
-
-et-log "Installing message of the day..."
-cp -v ../overlay/etc/motd /etc/
-
 et-log "Installing base packages..."
 
 apt install \
@@ -22,6 +15,7 @@ apt install \
   gpg \
   imagemagick \
   jq \
+  moreutils \
   net-tools \
   openjdk-20-jdk \
   openssh-server \
@@ -32,3 +26,11 @@ apt install \
   xsel \
   tree \
   -y
+
+et-log "Installing environment variables..."
+# TODO Can enviornment varialbes also be set in profile.d?
+cat <(grep -vE '^ET_' /etc/environment) ../overlay/etc/environment | sponge /etc/environment
+cp -v ../overlay/etc/profile.d/emcomm-tools.sh /etc/profile.d/
+
+et-log "Installing message of the day..."
+cp -v ../overlay/etc/motd /etc/


### PR DESCRIPTION
The prefered way to tweak thinks like `PATH`, is by using scripts in `/etc/profile.d`. Including $PATH while adding our own, allows other tools to add to PATH without them breaking.

This is a quality of live change, intended to prevent future headaches.

**How was this tested?**

* An image was build according to https://community.emcommtools.com/getting-stated/create-etc-image.html. Chanes to the command sequence are:
  * Step 8
    ```sh
    wget https://github.com/corvus-ch/emcomm-tools-os-community/archive/refs/heads/path.tar.gz
    ```
  * Step 9 & 10: paths adapted as needed.
* The image was installed in a virtual machine
* Tested if all binaries in `/opt/emcomm-tools/bin` are available through PATH lookup
   ```sh
   diff -u <(find /opt/emcomm-tools/bin/ -type f -executable | sort) <(find /opt/emcomm-tools/bin/ -type f -executable -exec bash -c 'command -v $(basename {})' \; | sort)
   ```
  No difference was found.
* Instpected the content of the `PATH` variable
  ```
  /opt/emcomm-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
   ```
* Tested udev rules and systemd unit environment
  * Connected a QRPLabs QMX and tested if rig control works
    This indicates that the `et-…` binaries are also found in the udev and systemd context, not only the logged-in user.