### PR TITLE
Adhere to users default browser

### DIFF
--- a/overlay/etc/skel/.config/mimeapps.list
+++ b/overlay/etc/skel/.config/mimeapps.list
@@ -1,0 +1,9 @@
+[Default Applications]
+x-scheme-handler/http=min.desktop
+x-scheme-handler/https=min.desktop
+text/html=min.desktop
+
+[Added Associations]
+x-scheme-handler/http=min.desktop;
+x-scheme-handler/https=min.desktop;
+text/html=min.desktop;

--- a/overlay/etc/skel/add-ons/docs/create-doc-site.sh
+++ b/overlay/etc/skel/add-ons/docs/create-doc-site.sh
@@ -22,4 +22,4 @@ gem install jekyll bundler && jekyll new ${SITE}
 
 echo -e "${YELLOW}1. Move into the site directory: ${WHITE}cd ${SITE}${NC}"
 echo -e "${YELLOW}2. Build and start site: ${WHITE}bundle exec jekyll serve${NC}" 
-echo -e "${YELLOW}3. Access site in web browser: ${WHITE}min http://localhost:4000${NC}" 
+echo -e "${YELLOW}3. Access site in web browser: ${WHITE}xdg-open http://localhost:4000${NC}"

--- a/overlay/opt/emcomm-tools/bin/et-common
+++ b/overlay/opt/emcomm-tools/bin/et-common
@@ -33,6 +33,21 @@ notify-user() {
   notify-send -t 5000 --app-name="EmComm Tools" "$1"
 }
 
+# Opens a URL in the default browser
+#
+# TODO Prevent script to exit when browser is already running.
+# Opening a URL is blocking if browser needs to start up first.
+# It is non blocking when browser is already running.
+#
+# Some scripts, use traps to clean up when the script exits.
+# The non-blocking case causes those scripts to exit prematurely.
+# This is known to be the case for `et-vr-n76`, `et-uv-pro` and `et-th-d74`.
+open-url() {
+  # `xdg-open` is the prefered and most standard way to open an URL on Linux.
+  # It will always be non-blocking and thus is not suitable in this context.
+  x-www-browser "$1" >/dev/null 2>&1
+}
+
 exit_if_no_sdr() {
   if [[ ! -e ${ET_DEVICE_SDR} ]]; then
     et-log "No ${ET_DEVICE_SDR} detected."

--- a/overlay/opt/emcomm-tools/bin/et-mode
+++ b/overlay/opt/emcomm-tools/bin/et-mode
@@ -4,6 +4,7 @@
 # Date     : 6 November 2024
 # Updated  : 25 March 2025
 # Purpose  : Configures the system for a specific mode of operation
+source /opt/emcomm-tools/bin/et-common
 
 # Use a simple text file to save the state of the last mode selected
 MODE_STATUS_FILE="${HOME}/.config/emcomm-tools/et-mode"
@@ -240,12 +241,12 @@ if [ $exit_status -eq 0 ]; then
       et-log "Using ARDOP as the modem."
       start_and_wait_for_service et-service-ardop
       start_and_wait_for_service et-service-winlink-ardop
-      min http://localhost:8080
+      open-url http://localhost:8080
     ;;
     ${MODE_ID_WINLINK_PACKET})
       start_and_wait_for_service et-service-direwolf-simple 
       start_and_wait_for_service et-service-winlink-packet
-      min http://localhost:8080
+      open-url http://localhost:8080
     ;;
     ${MODE_ID_WINLINK_VARA_FM})
       dialog --title "User Action Required" --msgbox "VARA FM is not a plug and play mode. You must configure VARA manually." 10 50
@@ -253,7 +254,7 @@ if [ $exit_status -eq 0 ]; then
       start_and_wait_for_vara et-vara-fm
       et-winlink start-vara-fm &
       sleep 1
-      min http://localhost:8080 2>/dev/null
+      open-url http://localhost:8080
     ;;
     ${MODE_ID_WINLINK_VARA_HF})
       dialog --title "User Action Required" --msgbox "VARA HF is not a plug and play mode. You must configure VARA manually." 10 50
@@ -261,7 +262,7 @@ if [ $exit_status -eq 0 ]; then
       start_and_wait_for_vara et-vara-hf
       et-winlink start-vara-hf &
       sleep 1
-      min http://localhost:8080 2>/dev/null
+      open-url http://localhost:8080
     ;;
     *)
       et-log "Mode ${SELECTED_MODE} not yet supported"

--- a/overlay/opt/emcomm-tools/bin/et-th-d74
+++ b/overlay/opt/emcomm-tools/bin/et-th-d74
@@ -300,7 +300,7 @@ EOF
         "Winlink")
           do_kiss_attach
           start_and_wait_for_service et-service-winlink-native-packet
-          min http://localhost:8080 1>/dev/null 2>&1
+          open-url http://localhost:8080
           break
           ;;
         "YAAC")

--- a/overlay/opt/emcomm-tools/bin/et-uv-pro
+++ b/overlay/opt/emcomm-tools/bin/et-uv-pro
@@ -289,7 +289,7 @@ EOF
         "Winlink")
           do_kiss_attach
           start_and_wait_for_service et-service-winlink-native-packet
-          min http://localhost:8080 1>/dev/null 2>&1
+          open-url http://localhost:8080
           break
           ;;
         "YAAC")

--- a/overlay/opt/emcomm-tools/bin/et-vr-n76
+++ b/overlay/opt/emcomm-tools/bin/et-vr-n76
@@ -290,7 +290,7 @@ EOF
         "Winlink")
           do_kiss_attach
           start_and_wait_for_service et-service-winlink-native-packet
-          min http://localhost:8080 1>/dev/null 2>&1
+          open-url http://localhost:8080
           break
           ;;
         "YAAC")

--- a/scripts/install-browser.sh
+++ b/scripts/install-browser.sh
@@ -49,3 +49,6 @@ else
   et-log "Brave already installed: $INSTALL_PATH. Skipping."
 fi
 
+et-log "Configuring Min as default web browser..."
+# The default browser for `xdg-open` is configured in `/etc/skel/.config/mimeapps.list`
+update-alternatives --set x-www-browser $(realpath $(command -v min))


### PR DESCRIPTION
Use Linux standards to open URLs in the default browser configured by the user.

If the PR gets merged, users of EmComm Tools can choose their favourite browser (by default Min and Brave are available). Others can be installed as well, and it will work. Switching to another browser is done by executing:

```sh
update-alternatives --config x-www-browser
```

A good discussion on the subject is available at https://thelinuxcode.com/open-default-browser-command-line-linux/.

While working on this PR, I discovered a bug.

Opening a URL is blocking if browser needs to start up first. It is non-blocking when browser is already running.

Some scripts, use traps to clean up when the script exits. The non-blocking case causes those scripts to exit prematurely. This is known to be the case for `et-vr-n76`, `et-uv-pro` and `et-th-d74`. The 'et-mode' script is unaffected, as it does currently not use traps for clean up.

Steps to trigger the bug:

1. Open the Min web browser
2. Connect to a Bluetooth radio (`et-vr-76 c`, `et-uv-pro c`, `et-th-d74 c`).
3. Select "3 Winlink"

Observed behaviour:

* Connection to the bluetooth radio gets establisched.
* The Pat ui gets opened in a new browser tab
* The script exits, killing the bluetooth connection

Mitigation:

* Close browser and try again

This PR does not fix this bug, I does not make the situation worse.