### PR TITLE
Bugfix for improperly initialized user services

### DIFF
--- a/overlay/etc/skel/.config/autostart/enable-et-systemd-services.desktop
+++ b/overlay/etc/skel/.config/autostart/enable-et-systemd-services.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Exec=/bin/bash -c '$HOME/enable-systemd-services.sh'
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name=Enable EmComm Tools Systemd Services
+Comment=Enable systemd user services on first login

--- a/overlay/etc/skel/.config/systemd/user/default.target.wants/et-service-et-api.service
+++ b/overlay/etc/skel/.config/systemd/user/default.target.wants/et-service-et-api.service
@@ -1,1 +1,0 @@
-../et-service-et-api.service

--- a/overlay/etc/skel/.config/systemd/user/default.target.wants/et-service-mbtileserver.service
+++ b/overlay/etc/skel/.config/systemd/user/default.target.wants/et-service-mbtileserver.service
@@ -1,1 +1,0 @@
-../et-service-mbtileserver.service

--- a/overlay/etc/skel/enable-systemd-services.sh
+++ b/overlay/etc/skel/enable-systemd-services.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Author  : Clifton Jones
+# Date    : 31 December 2025
+# Purpose : Run-once script to enable systemd user services on first graphical login
+#
+# This script enables the et-service-et-api and et-service-mbtileserver
+# systemd user services when a new user logs into the graphical environment
+# for the first time.
+
+# Enable the systemd user services
+systemctl --user enable et-service-et-api
+systemctl --user enable et-service-mbtileserver
+
+# Reload systemd user daemon to pick up changes
+systemctl --user daemon-reload
+
+# Start the services
+systemctl --user start et-service-et-api
+systemctl --user start et-service-mbtileserver
+
+# Remove this autostart entry so it doesn't run again
+rm -f "${HOME}/.config/autostart/enable-et-systemd-services.desktop"
+
+exit 0


### PR DESCRIPTION
Removed improperly created systemd enablement directory/files. 
Created a run-once setup script to enable user systemd scripts for auto-run.