### PR TITLE
Add radio config for Lab599 TX-500

### DIFF
--- a/overlay/opt/emcomm-tools/conf/radios.d/lab599-tx500.json
+++ b/overlay/opt/emcomm-tools/conf/radios.d/lab599-tx500.json
@@ -1,0 +1,21 @@
+{
+  "id": "lab599-tx500",
+  "vendor": "Lab599",
+  "model": "TX-500 (DigiRig Mobile)",
+  "rigctrl": {
+    "id": "2002",
+    "baud": "9600",
+    "ptt": "RTS",
+    "pttOnly": "false"
+  },
+  "audio": {
+    "script": "/opt/emcomm-tools/conf/radios.d/audio/lab599-tx500mp.sh"
+  },
+  "notes": [
+    "1. Set MODE = DIGI",
+    "",
+    "Ensure VOX is disabled"
+  ],
+  "fieldNotes": [
+  ]
+}


### PR DESCRIPTION
The TX-500 requires a different CAT protocol than it's man portable sibling (TX-500MP).

The manual is quite fuzzy here. It only states Kennwood. On my rig (firmware 1.14.10), the TS-2000 configure for the TX-500MP does not work, while the TS-440S protocoll does.